### PR TITLE
Update change log and build extentions v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+[Released]: v1.0.4
+16-06-2022: 
+- String Binding support format datetime, double, decimal ex: {DatetimePropertyName:dd-MM-yyyy}, {doublePropertyName:dd-MM-yyyy}
+- Add GetGenericTypeName function 
+[1.0.4]: https://github.com/coderstrong/MakeSimple.SharedKernel.Extensions/releases/tag/v1.0.4
+
 [Released]: v1.0.1
 03-06-2022: Add function object to dictionary
-[1.2.1]: https://github.com/coderstrong/MakeSimple.SharedKernel.Extensions/releases/tag/v1.0.1
+[1.0.1]: https://github.com/coderstrong/MakeSimple.SharedKernel.Extensions/releases/tag/v1.0.1
 
 [Released]: v1.0.0
 27-01-2022: Add binding object properties to string format

--- a/MakeSimple.SharedKernel.sln
+++ b/MakeSimple.SharedKernel.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakeSimple.EventHub", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MakeSimple.EventHub.GoogleClound", "src\MakeSimple.EventHub.GoogleClound\MakeSimple.EventHub.GoogleClound.csproj", "{982D3C68-5337-4241-9530-3F9F8C5F9452}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MakeSimple.SharedKernel.Extensions.Test", "src\MakeSimple.SharedKernel.Extensions.Test\MakeSimple.SharedKernel.Extensions.Test.csproj", "{6F18FA6E-4EA3-4659-BD65-D83110F52F78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{982D3C68-5337-4241-9530-3F9F8C5F9452}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{982D3C68-5337-4241-9530-3F9F8C5F9452}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{982D3C68-5337-4241-9530-3F9F8C5F9452}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F18FA6E-4EA3-4659-BD65-D83110F52F78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F18FA6E-4EA3-4659-BD65-D83110F52F78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F18FA6E-4EA3-4659-BD65-D83110F52F78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F18FA6E-4EA3-4659-BD65-D83110F52F78}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MakeSimple.SharedKernel.Extensions.Test/MakeSimple.SharedKernel.Extensions.Test.csproj
+++ b/src/MakeSimple.SharedKernel.Extensions.Test/MakeSimple.SharedKernel.Extensions.Test.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MakeSimple.SharedKernel.Extensions\MakeSimple.SharedKernel.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MakeSimple.SharedKernel.Extensions.Test/StringBindingExtentionsTest.cs
+++ b/src/MakeSimple.SharedKernel.Extensions.Test/StringBindingExtentionsTest.cs
@@ -1,0 +1,80 @@
+using System;
+using Xunit;
+
+namespace MakeSimple.SharedKernel.Extensions.Test
+{
+    public class StringBindingExtentionsTest
+    {
+        [Fact]
+        public void Test_AnonymousType_Binding_With_Format()
+        {
+            // Arrange
+            var Template = "Tran Van {Name}, Sinh nhat: {Birthday:dd-MM-yyyy}, Tien: {Money:G}";
+            var Data = new
+            {
+                Name = "Thao",
+                Birthday = DateTime.Now,
+                Money = 20
+            };
+            // Act
+            var actual = Template.BindObjectProperties(Data);
+            var expected = $"Tran Van Thao, Sinh nhat: {Data.Birthday:dd-MM-yyyy}, Tien: {Data.Money:G}";
+            // Assert
+            Assert.True(actual == expected);
+        }
+
+        [Fact]
+        public void Test_AnonymousType_Binding_Without_Format()
+        {
+            // Arrange
+            var Template = "Tran Van {Name}";
+            var Data = new
+            {
+                Name = "Thao"
+            };
+            // Act
+            var actual = Template.BindObjectProperties(Data);
+            var expected = $"Tran Van Thao";
+            // Assert
+            Assert.True(actual == expected);
+        }
+
+        [Fact]
+        public void Test_JsonElementType_Binding_With_Format()
+        {
+            // Arrange
+            var Template = "Tran Van {Name}, Sinh nhat: {Birthday:dd-MM-yyyy}, Tien: {Money:G}";
+            var Data = new
+            {
+                Name = "Thao",
+                Birthday = DateTime.Now,
+                Money = 20
+            };
+
+            var elementObj = (System.Text.Json.JsonElement)System.Text.Json.JsonSerializer.Deserialize<object>(System.Text.Json.JsonSerializer.Serialize(Data));
+            // Act
+            var actual = Template.BindObjectProperties(elementObj);
+            var expected = $"Tran Van Thao, Sinh nhat: {Data.Birthday:dd-MM-yyyy}, Tien: {Data.Money:G}";
+            // Assert
+            Assert.True(actual == expected);
+        }
+
+        [Fact]
+        public void Test_JsonElementType_Binding_Without_Format()
+        {
+            // Arrange
+            var Template = "Tran Van {Name}";
+            var Data = new
+            {
+                Name = "Thao"
+            };
+
+            var elementObj =(System.Text.Json.JsonElement) System.Text.Json.JsonSerializer.Deserialize<object>(System.Text.Json.JsonSerializer.Serialize(Data));
+            // Act
+            var actual = Template.BindObjectProperties(elementObj);
+            var expected = $"Tran Van Thao";
+            // Assert
+            Assert.True(actual == expected);
+        }
+    }
+}

--- a/src/MakeSimple.SharedKernel.Extensions/GenericTypeExtensions.cs
+++ b/src/MakeSimple.SharedKernel.Extensions/GenericTypeExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+
+namespace MakeSimple.SharedKernel.Extensions
+{
+    /// <summary>
+    /// Source: https://raw.githubusercontent.com/dotnet-architecture/eShopOnContainers/dev/src/BuildingBlocks/EventBus/EventBus/Extensions/GenericTypeExtensions.cs
+    /// </summary>
+    public static class GenericTypeExtensions
+    {
+        public static string GetGenericTypeName(this Type type)
+        {
+            var typeName = string.Empty;
+
+            if (type.IsGenericType)
+            {
+                var genericTypes = string.Join(",", type.GetGenericArguments().Select(t => t.Name).ToArray());
+                typeName = $"{type.Name.Remove(type.Name.IndexOf('`'))}<{genericTypes}>";
+            }
+            else
+            {
+                typeName = type.Name;
+            }
+
+            return typeName;
+        }
+
+        public static string GetGenericTypeName(this object @object)
+        {
+            return @object.GetType().GetGenericTypeName();
+        }
+    }
+}

--- a/src/MakeSimple.SharedKernel.Extensions/MakeSimple.SharedKernel.Extensions.csproj
+++ b/src/MakeSimple.SharedKernel.Extensions/MakeSimple.SharedKernel.Extensions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <SonarQubeExclude>True</SonarQubeExclude>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <PackageIcon>logo.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>
     <ApplicationIcon>logo.ico</ApplicationIcon>


### PR DESCRIPTION
[Released]: v1.0.4 
16-06-2022:  
- String Binding support format datetime, double, decimal ex: {DatetimePropertyName:dd-MM-yyyy}, {doublePropertyName:dd-MM-yyyy} 
- Add GetGenericTypeName function  
[1.0.4]: https://github.com/coderstrong/MakeSimple.SharedKernel.Extensions/releases/tag/v1.0.4 
 